### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: python
-sudo: false
+dist: xenial
 python:
     - 2.7
-    - 3.4
     - 3.5
     - 3.6
+    - 3.7
     - pypy
     - pypy3
-matrix:
-    include:
-        - python: "3.7"
-          dist: xenial
-          sudo: true
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@
  Changes
 =========
 
-4.3.1 (unreleased)
+4.4.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Drop support for Python 3.4.
 
 
 4.3.0 (2018-10-05)

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,14 @@
 import os
 from setuptools import setup, find_packages
 
+
 def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
         return f.read()
 
+
 long_description = (read('README.rst') + '\n\n' + read('CHANGES.rst'))
+
 
 def alltests():
     import sys
@@ -36,6 +39,7 @@ def alltests():
     suites = list(zope.testrunner.find.find_suites(options))
     return unittest.TestSuite(suites)
 
+
 TESTS_REQUIRE = [
     'zope.browsermenu',
     'zope.testing',
@@ -44,7 +48,7 @@ TESTS_REQUIRE = [
 
 setup(
     name='zope.browserpage',
-    version='4.3.1.dev0',
+    version='4.4.0.dev0',
     url='https://github.com/zopefoundation/zope.browserpage',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
@@ -56,7 +60,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,pypy,py34,py35,py36,py37,pypy3,coverage
+    py27,py35,py36,py37,pypy,pypy3,coverage
 
 [testenv]
 commands =
@@ -13,7 +13,7 @@ deps =
 usedevelop = true
 commands =
     coverage run -m zope.testrunner --test-path=src []
-    coverage report --fail-under=100
+    coverage report --fail-under=100 -m
 deps =
     {[testenv]deps}
     coverage


### PR DESCRIPTION
Python 3.4 was EOLed on March 18, 2019:
https://devguide.python.org/devcycle/#end-of-life-branches

(Some PEP-8 fixes to setup.py and a coverage report -m fix also snuck in.)